### PR TITLE
Fix application config name error when running tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,8 +1,8 @@
 use Mix.Config
 
-config :integration, event_stores: [Integration.EventStore]
+config :horde_registry_commanded, event_stores: [Integration.EventStore]
 
-config :integration, Integration.EventStore,
+config :horde_registry_commanded, Integration.EventStore,
   registry: :distributed,
   serializer: Commanded.Serialization.JsonSerializer,
   username: "postgres",

--- a/config/worker.exs
+++ b/config/worker.exs
@@ -1,8 +1,8 @@
 use Mix.Config
 
-import_config "config.exs"
+import_config "test.exs"
 
-config :integration,
+config :horde_registry_commanded,
   children: [
     Integration.App,
     HordeRegistryCommanded.NodeListener

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule HordeRegistryCommanded.MixProject do
     |> Keyword.merge(project(Mix.env()))
   end
 
-  def project(:test), do: [config_path: "config/config.exs"]
+  def project(:test), do: [config_path: "config/test.exs"]
   def project(_), do: []
 
   # Run "mix help compile.app" to learn about applications.

--- a/test/support/app.ex
+++ b/test/support/app.ex
@@ -2,7 +2,7 @@ defmodule Integration.App do
   @moduledoc false
 
   use Commanded.Application,
-    otp_app: :integration,
+    otp_app: :horde_registry_commanded,
     registry: HordeRegistryCommanded.HordeRegistry,
     event_store: [
       adapter: Commanded.EventStore.Adapters.EventStore,

--- a/test/support/application.ex
+++ b/test/support/application.ex
@@ -10,7 +10,7 @@ defmodule Integration.Application do
       [
         # Starts a worker by calling: Integration.Worker.start_link(arg)
         # {Integration.Worker, arg}
-      ] ++ (Application.get_env(:integration, :children) || [])
+      ] ++ (Application.get_env(:horde_registry_commanded, :children) || [])
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -34,9 +34,9 @@ defmodule Integration.Cluster do
     for {key, val} <-
           Keyword.get(
             :rpc.block_call(node, Config.Reader, :read!, ["config/worker.exs"]),
-            :integration
+            :horde_registry_commanded
           ) do
-      :rpc.block_call(node, Application, :put_env, [:integration, key, val])
+      :rpc.block_call(node, Application, :put_env, [:horde_registry_commanded, key, val])
     end
 
     # Start Apps

--- a/test/support/event_store.ex
+++ b/test/support/event_store.ex
@@ -1,5 +1,5 @@
 defmodule Integration.EventStore do
   @moduledoc false
 
-  use EventStore, otp_app: :integration
+  use EventStore, otp_app: :horde_registry_commanded
 end


### PR DESCRIPTION
This PR removes the following warning when running tests:

```
You have configured application :integration in your configuration file,
but the application is not available.

This usually means one of:

  1. You have not added the application as a dependency in a mix.exs file.

  2. You are configuring an application that does not really exist.

Please ensure :integration exists or remove the configuration.
```

I also took the liberty to rename `config.exs` to `test.exs` since it's only used in the test environment.